### PR TITLE
Callback return types should be any()

### DIFF
--- a/lib/absinthe_metrics.ex
+++ b/lib/absinthe_metrics.ex
@@ -2,8 +2,8 @@ defmodule AbsintheMetrics do
   alias Absinthe.Resolution
   @behaviour Absinthe.Middleware
 
-  @callback instrument(object :: atom, field :: atom, result :: any, time :: non_neg_integer) :: none
-  @callback field(object :: String.t, field :: String.t, args :: []) :: none
+  @callback instrument(object :: atom, field :: atom, result :: any, time :: non_neg_integer) :: any
+  @callback field(object :: String.t, field :: String.t, args :: []) :: any
 
   defmacro __using__(opts) do
     adapter = Keyword.get(opts, :adapter, AbsintheMetrics.Backend.Echo)

--- a/lib/absinthe_metrics.ex
+++ b/lib/absinthe_metrics.ex
@@ -8,6 +8,10 @@ defmodule AbsintheMetrics do
   defmacro __using__(opts) do
     adapter = Keyword.get(opts, :adapter, AbsintheMetrics.Backend.Echo)
     arguments = Keyword.get(opts, :arguments, [])
+    wrapped_arguments = case arguments do
+      [] -> []
+      arguments -> [arguments]
+    end
 
     quote do
       def instrument([], _field, _obj), do: []
@@ -28,13 +32,9 @@ defmodule AbsintheMetrics do
         end
 
         for %{fields: fields} = object <- Absinthe.Schema.types(schema),
-          {k, %Absinthe.Type.Field{name: name, identifier: id} = field} <- fields,
-          instrumented?.(field) do
-            arguments = case unquote(arguments) do
-              [] -> []
-              arguments -> [arguments]
-            end
-            apply(unquote(adapter), :field, [object.identifier, field.identifier] ++ arguments)
+            {k, %Absinthe.Type.Field{name: name, identifier: id} = field} <- fields,
+            instrumented?.(field) do
+          apply(unquote(adapter), :field, [object.identifier, field.identifier] ++ unquote(wrapped_arguments))
         end
       end
     end


### PR DESCRIPTION
- none() explicitly means the function should never return and should
  always raise
- This causes dialyzer to fail if an implementation does not raise (i.e.
  it will always fail for any sane implementation)
- We don't care about the return value so any() is fine