### PR TITLE
Fix absinthe middleware spec

### DIFF
--- a/lib/absinthe_metrics.ex
+++ b/lib/absinthe_metrics.ex
@@ -19,14 +19,14 @@ defmodule AbsintheMetrics do
       def instrument(middleware, %{__reference__: %{module: Absinthe.Type.BuiltIns.Introspection}}, _obj), do: middleware
 
       def instrument(middleware, field, _obj)  do
-        [{{AbsintheMetrics}, {unquote(adapter), unquote(arguments)}} | middleware]
+        [{{AbsintheMetrics, :call}, {unquote(adapter), unquote(arguments)}} | middleware]
       end
 
       def install(schema) do
         instrumented? = fn %{middleware: middleware} = field ->
           middleware
           |> Enum.any?(fn
-            {{AbsintheMetrics}, _} -> true
+            {{AbsintheMetrics, :call}, _} -> true
             _ -> false
           end)
         end
@@ -40,7 +40,7 @@ defmodule AbsintheMetrics do
     end
   end
 
-  def call(%Resolution{state: :unresolved} = res, {adapter, _}, _config) do
+  def call(%Resolution{state: :unresolved} = res, {adapter, _}) do
     now = :erlang.monotonic_time()
     %{res | middleware: res.middleware ++ [{{AbsintheMetrics, :after_resolve}, start_at: now, adapter: adapter, field: res.definition.schema_node.identifier, object: res.parent_type.identifier}]}
   end


### PR DESCRIPTION
Absinthe [docs](https://hexdocs.pm/absinthe/Absinthe.Middleware.html#module-default-middleware) suggest using form `{{Module, :func}, opts}`.
The only reason previous implementation worked at all is because:
1) Absinthe has undocumented middleware format of `{Module, opts}`, which does not check that `Module` is an atom and simply call `apply(Module, :call, [opts])`, which in this case was `apply({AbsintheMetrics}, :call, [resolution, opts])`
2) Erlang's apply has undocumented feature: when it is called like that (`apply({AbsintheMetrics}, :call, [resolution, opts])`) it actually does `AbsintheMetrics.call(resolution, opts, {AbsintheMetrics})`. It's probably leftover implementation of `apply/2` accepting `{Module, :func}`, which is now deprecated and soon to be removed.

Also it should fix compiler warning about `AbsintheMetrics.call/2` being required for behaviour `Absinthe.Middleware`, but not defined.