### PR TITLE
Fix travis, otp 19.1 isn't supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 sudo: false
 elixir: 1.4.4
-otp_release: 19.1
+otp_release: 19.3
 notifications:
   recipients:
     - fredrik.enestad@soundtrackyourbrand.com


### PR DESCRIPTION
19.3 is the closes supported otp version by travis